### PR TITLE
Make loki settings optional

### DIFF
--- a/export.py
+++ b/export.py
@@ -121,7 +121,8 @@ def prom_client(config):
     # create the WekaCollector object
     collector = WekaCollector(config, cluster_obj)
 
-    if config['exporter']['loki_host'] is not None:
+    loki_host = config['exporter'].get('loki_host')
+    if loki_host:
         try:
             lokiserver = LokiServer(config['exporter']['loki_host'], config['exporter']['loki_port'], maps)
         except:


### PR DESCRIPTION
Closes https://github.com/weka/export/issues/47

This change allows for the "loki_host" and "loki_port" settings to be optional in the configuration file


