### PR TITLE
feat: add `host_ip` option for exporter metrics

### DIFF
--- a/export.py
+++ b/export.py
@@ -209,16 +209,17 @@ def prom_client(config):
     # Start up the server to expose the metrics.
     #
     if not events_only:
-        log.info(f"starting http server on port {config['exporter']['listen_port']}")
+        log.info(f"starting http server on {config['exporter']['host_ip']}:{config['exporter']['listen_port']}")
         try:
             if config['exporter']['certfile'] is not None and config['exporter']['keyfile'] is not None:
                 prometheus_client.start_http_server(int(config['exporter']['listen_port']),
                                                     certfile=config['exporter']['certfile'],
+                                                    addr=config['exporter']['host_ip'],
                                                     keyfile=config['exporter']['keyfile'])
             else:
-                prometheus_client.start_http_server(int(config['exporter']['listen_port']))
+                prometheus_client.start_http_server(int(config['exporter']['listen_port']), addr=config['exporter']['host_ip'])
         except Exception as exc:
-            log.critical(f"Unable to start http server on port {config['exporter']['listen_port']}: {exc}")
+            log.critical(f"Unable to start http server on {config['exporter']['host_ip']}:{config['exporter']['listen_port']}: {exc}")
             return 1
 
         # register our custom collector

--- a/export.yml
+++ b/export.yml
@@ -4,6 +4,7 @@
 
 # exporter section - info about how we're going to run
 exporter:
+  host_ip: 0.0.0.0
   listen_port: 8150
   events_only: False
   events_to_loki: True


### PR DESCRIPTION
Hi,

Would it possible to add an option to configure the `host IP` for the exporter metrics endpoint ?
Currently, it defaults to binding on `0.0.0.0`. However, there are cases where users may prefer to bind it to `127.0.0.1` or another specific IP address for security reasons.